### PR TITLE
fix: make access-widener optional

### DIFF
--- a/java21/src/main/java/org/leavesmc/leavesclip/mixin/AccessWidenerManager.java
+++ b/java21/src/main/java/org/leavesmc/leavesclip/mixin/AccessWidenerManager.java
@@ -22,7 +22,7 @@ public class AccessWidenerManager {
     public static void initAccessWidener(URLClassLoader classLoader) {
         AccessWidenerReader reader = new AccessWidenerReader(instance);
         for (String config : MixinJarResolver.accessWidenerConfigs) {
-            if (config.isEmpty() || config == null) continue;
+            if (config == null || config.isEmpty()) continue;
             applyAccessWidenerConfig(classLoader, config, reader);
         }
     }

--- a/java21/src/main/java/org/leavesmc/leavesclip/mixin/AccessWidenerManager.java
+++ b/java21/src/main/java/org/leavesmc/leavesclip/mixin/AccessWidenerManager.java
@@ -22,6 +22,7 @@ public class AccessWidenerManager {
     public static void initAccessWidener(URLClassLoader classLoader) {
         AccessWidenerReader reader = new AccessWidenerReader(instance);
         for (String config : MixinJarResolver.accessWidenerConfigs) {
+            if (config.isEmpty() || config == null) continue;
             applyAccessWidenerConfig(classLoader, config, reader);
         }
     }


### PR DESCRIPTION
目前的插件mixin实现中，如果leaves-plugin.json里的access-widener不存在或者是空，那么服务端会在启动时崩溃，此PR使access-widener变为可选的

附：崩溃日志
leaves-plugin.json中存在"access-widener": ""时
```txt
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:115)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.leavesmc.leavesclip.Main.main(Main.java:26)
Caused by: java.lang.NullPointerException: Cannot invoke "String.split(String)" because "headerLine" is null
        at net.fabricmc.accesswidener.AccessWidenerReader.readHeader(AccessWidenerReader.java:155)
        at net.fabricmc.accesswidener.AccessWidenerReader.read(AccessWidenerReader.java:78)
        at net.fabricmc.accesswidener.AccessWidenerReader.read(AccessWidenerReader.java:67)
        at org.leavesmc.leavesclip.mixin.AccessWidenerManager.applyAccessWidenerConfig(AccessWidenerManager.java:35)
        at org.leavesmc.leavesclip.mixin.AccessWidenerManager.initAccessWidener(AccessWidenerManager.java:25)
        at org.leavesmc.leavesclip.Leavesclip.main(Leavesclip.java:71)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        ... 2 more
```
不存在时
```txt
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:115)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.leavesmc.leavesclip.Main.main(Main.java:26)
Caused by: java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:233)
        at java.base/java.net.URLClassLoader.getResourceAsStream(URLClassLoader.java:289)
        at org.leavesmc.leavesclip.mixin.AccessWidenerManager.applyAccessWidenerConfig(AccessWidenerManager.java:30)
        at org.leavesmc.leavesclip.mixin.AccessWidenerManager.initAccessWidener(AccessWidenerManager.java:25)
        at org.leavesmc.leavesclip.Leavesclip.main(Leavesclip.java:71)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        ... 2 more
```